### PR TITLE
Fix for issue #4

### DIFF
--- a/mkdocs_autolinks_plugin/plugin.py
+++ b/mkdocs_autolinks_plugin/plugin.py
@@ -2,7 +2,15 @@ import re
 import os
 from mkdocs.plugins import BasePlugin
 
-AUTOLINK_RE = r'\[([^\]]+)\]\(([^)/]+\.(md|png|jpg))\)'
+# For Regex, match groups are:
+#       0: Whole markdown link e.g. [Alt-text](url)
+#       1: Alt text
+#       2: Full URL e.g. url + hash anchor
+#       3: Filename e.g. filename.md
+#       4: File extension e.g. .md, .png, etc.
+#       5. hash anchor e.g. #my-sub-heading-link
+
+AUTOLINK_RE = r'\[([^\]]+)\]\((([^)/]+\.(md|png|jpg))(#.*)*)\)'
 # (?<!```\n)\[([^\]]+)\]\(([^)/]+\.md)\)
 class AutoLinkReplacer:
     def __init__(self, base_docs_url, page_url):
@@ -11,7 +19,7 @@ class AutoLinkReplacer:
 
     def __call__(self, match):
         # Name of the markdown file
-        filename = match.group(2).strip()
+        filename = match.group(3).strip()
 
         # Absolute URL of the linker
         abs_linker_url = os.path.dirname(os.path.join(self.base_docs_url, self.page_url))
@@ -32,7 +40,10 @@ class AutoLinkReplacer:
             return match.group(0)
 
         # Construct the return link by replacing the filename with the relative path to the file
-        link = match.group(0).replace(match.group(2), rel_link_url)
+        if(match.group(5) == None):
+            link = match.group(0).replace(match.group(2), rel_link_url)
+        else:
+            link = match.group(0).replace(match.group(2), rel_link_url + match.group(5))
 
         return link
 


### PR DESCRIPTION
Thanks @midnightprioriem for this plugin that helped with my documentation!

I was running into the same issue as @chrieke, and the fix seemed trivial, so I made this fork and tested locally... all runs as expected.

With this PR, you can add the hash-links at the end of a filename and have them added back in after the relative link is resolved from, the filesystem crawl.

The regex now generates the following match groups for [Link Text](filename.md#anchor-link):
0: Whole link markup - `[Link Text](filename.md#anchor-link)`
1: Link text part without brackets - `Link Text`
2: Full URL without parentheses including hash anchor if present - `filename.md#anchor-link`
3: Filename without any hash anchor if present - `filename.md`
4: File extension - `.md`
5: Hash anchor with hash mark - `#anchor-link`

Because the match group numbers changed, I had to change references in some other lines.

Thanks again!