### PR TITLE
Bugfix: Fix rel links from nested folders

### DIFF
--- a/mkdocs_autolinks_plugin/plugin.py
+++ b/mkdocs_autolinks_plugin/plugin.py
@@ -1,5 +1,7 @@
 import re
 import os
+from urllib.parse import quote
+
 from mkdocs.plugins import BasePlugin
 
 # For Regex, match groups are:
@@ -39,6 +41,7 @@ class AutoLinkReplacer:
             print('WARNING: AutoLinksPlugin unable to find ' + filename + ' in directory ' + self.base_docs_url)
             return match.group(0)
 
+        rel_link_url = quote(rel_link_url)
         # Construct the return link by replacing the filename with the relative path to the file
         if(match.group(5) == None):
             link = match.group(0).replace(match.group(2), rel_link_url)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mkdocs-autolinks-plugin',
-    version='0.2.0',
+    version='0.2.1',
     description='An MkDocs plugin',
     long_description='An MkDocs plugin that automagically generates relative links between markdown pages',
     keywords='mkdocs',


### PR DESCRIPTION
* What fixed this issue on my end, was simply URL quoting the resultant
  rel_link_url. I am on Windows, and all of the rel-paths came up as
  '..\\..' (Note the backslashes). The links looked correct leaving the
  plugin, but something in mkdocs core must have been eating / removing
  all unescaped backslashes, which lead to the broken links.

  By escaping the link URL, it prevents that replacement from occuring,
  thus the links begin working again.

Issue: https://github.com/midnightprioriem/mkdocs-autolinks-plugin/issues/6