### PR TITLE
Add support for empty alt text images

### DIFF
--- a/mkdocs_autolinks_plugin/plugin.py
+++ b/mkdocs_autolinks_plugin/plugin.py
@@ -10,7 +10,7 @@ from mkdocs.plugins import BasePlugin
 #       4: File extension e.g. .md, .png, etc.
 #       5. hash anchor e.g. #my-sub-heading-link
 
-AUTOLINK_RE = r'\[([^\]]+)\]\((([^)/]+\.(md|png|jpg))(#.*)*)\)'
+AUTOLINK_RE = r'(?:\!\[\]|\[([^\]]+)\])\((([^)/]+\.(md|png|jpg))(#.*)*)\)'
 # (?<!```\n)\[([^\]]+)\]\(([^)/]+\.md)\)
 class AutoLinkReplacer:
     def __init__(self, base_docs_url, page_url):


### PR DESCRIPTION
* Support empty alt text in an image tag.
    e.g. `![](my-image.png)`

* This fix simply  modifies the link capture regex to conditionally
  scan for *either* explicitly an Image tag with empty braces, but
  not a Link with empty braces. Although a new capture group is
  added, it is discarded, so the group structure remains unaltered.

Issue: #13 