### PR TITLE
Log Warning for duplicate only if relevant file

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,17 @@ The Autolinks plugin also works with `jpg` and `png` files:
 # onboarding.md
 ![Avatar](avatar.png)
 ```
+
+## Options
+
+### Display error in the html 
+
+If you want that files not found display an error in the html rendered file (i.e. a link of the form `<a href=".">Error : unable to find "file.md"</a>`) you can do :
+
+```yaml
+plugins:
+  - search
+  - autolinks:
+      html_error_if_invalid: true
+```
+in your `mkdocs.yml` file

--- a/mkdocs_autolinks_plugin/plugin.py
+++ b/mkdocs_autolinks_plugin/plugin.py
@@ -127,7 +127,7 @@ class AutoLinksPlugin(BasePlugin):
 
         if self.config["warn_not_found_anchors"]:
             soup = BeautifulSoup(html, "html.parser")
-            titles = soup.find_all(("h1", "h2", "h3", "h4", "h5"))
+            titles = soup.find_all(("h1", "h2", "h3", "h4", "h5", "figure"))
 
             for title in titles:
                 self.existing_anchors.append(

--- a/mkdocs_autolinks_plugin/plugin.py
+++ b/mkdocs_autolinks_plugin/plugin.py
@@ -79,14 +79,23 @@ class AutoLinksPlugin(BasePlugin):
         self.filename_to_abs_path = {}
         for file_ in files:
             filename = os.path.basename(file_.abs_src_path)
+            file_ext = filename.split(os.extsep)[-1]
 
             if filename in self.filename_to_abs_path:
-                LOG.warning(
-                    "Duplicate filename: '%s' exists at both '%s' and '%s'",
-                    filename,
-                    file_.abs_src_path,
-                    self.filename_to_abs_path[filename],
-                )
+                if file_ext in ["md", "png", "jpg", "jpeg", "bmp", "gif"]:
+                    LOG.warning(
+                        "AutoLinksPlugin : Duplicate filename: '%s' exists at both '%s' and '%s'",
+                        filename,
+                        file_.abs_src_path,
+                        self.filename_to_abs_path[filename],
+                    )
+                else:
+                    LOG.debug(
+                        "AutoLinksPlugin : Duplicate filename: '%s' exists at both '%s' and '%s'",
+                        filename,
+                        file_.abs_src_path,
+                        self.filename_to_abs_path[filename],
+                    )
                 continue
 
             self.filename_to_abs_path[filename] = file_.abs_src_path


### PR DESCRIPTION
I have some code that is shipped with the documentation I'm building. So the pluging was issuing a lot of Warning for 'main.cpp' files & co, but this is useless since it cannot be linked to anyway.

So I made this little modification to your code. Feel free to merge.

And thanks for the job by the way. Made my life easier