### PR TITLE
Add `.svg` support

### DIFF
--- a/mkdocs_autolinks_plugin/plugin.py
+++ b/mkdocs_autolinks_plugin/plugin.py
@@ -18,7 +18,7 @@ LOG.addFilter(warning_filter)
 #       4: File extension e.g. .md, .png, etc.
 #       5. hash anchor e.g. #my-sub-heading-link
 
-AUTOLINK_RE = r'(?:\!\[\]|\[([^\]]+)\])\((([^)/]+\.(md|png|jpg|jpeg|bmp|gif))(#[^)]*)*)\)'
+AUTOLINK_RE = r'(?:\!\[\]|\[([^\]]+)\])\((([^)/]+\.(md|png|jpg|jpeg|bmp|gif|svg))(#[^)]*)*)\)'
 
 
 class AutoLinkReplacer:


### PR DESCRIPTION
This pull request adds `.svg` support to `mkdocs-autolinks-plugin`.

Signed-off-by: Simon Hoinkis <simon.hoinkis@apex.ai>