### PR TITLE
Add image title support

### DIFF
--- a/mkdocs_autolinks_plugin/plugin.py
+++ b/mkdocs_autolinks_plugin/plugin.py
@@ -18,9 +18,10 @@ LOG.addFilter(warning_filter)
 #       3: Filename e.g. filename.md
 #       4: File extension e.g. .md, .png, etc.
 #       5. hash anchor e.g. #my-sub-heading-link
+#       6. Image title (in quotation marks)
 
 AUTOLINK_RE = (
-    r"(?:\!\[\]|\[([^\]]+)\])\((([^)/]+\.(md|png|jpg|jpeg|bmp|gif|svg|webp))(#[^)]*)*)\)"
+    r"(?:\!\[\]|\[([^\]]+)\])\((([^)/]+\.(md|png|jpg|jpeg|bmp|gif|svg|webp))(#[^)]*)*)(\s(\".*\"))*\)"
 )
 
 class AutoLinkReplacer:


### PR DESCRIPTION
Modifies the regular expression to cover [image titles, provided in quotation marks](https://github.github.com/gfm/#link-title):

`![Image alt](image.png "Image title")`

Should resolve https://github.com/midnightprioriem/mkdocs-autolinks-plugin/issues/8