### PR TITLE
Extend support

### DIFF
--- a/mkdocs_autolinks_plugin/plugin.py
+++ b/mkdocs_autolinks_plugin/plugin.py
@@ -20,7 +20,7 @@ LOG = logging.getLogger("mkdocs.plugins." + __name__)
 #       6. Image title (in quotation marks)
 
 AUTOLINK_RE = (
-    r"(?:\!\[\]|\[([^\]]+)\])\((([^)/]+\.(md|png|jpg|jpeg|bmp|gif|svg|webp))(#[^)]*)*)(\s(\".*\"))*\)"
+    r"(?:\!\[\]|\[([^\]]+)\])\((([^)/]+(\.md|\.png|\.jpg|\.jpeg|\.bmp|\.gif|\.svg|\.webp|/))(#[^)]*)*)(\s(\".*\"))*\)"
 )
 
 class AutoLinkReplacer:
@@ -93,4 +93,6 @@ class AutoLinksPlugin(BasePlugin):
         self.filename_to_abs_path = defaultdict(list)
         for file_ in files:
             filename = os.path.basename(file_.abs_src_path)
+            if filename == "index.md":
+                filename = os.path.basename(os.path.dirname(file_.abs_src_path)) + "/"
             self.filename_to_abs_path[filename].append(file_.abs_src_path)

--- a/mkdocs_autolinks_plugin/plugin.py
+++ b/mkdocs_autolinks_plugin/plugin.py
@@ -23,6 +23,10 @@ AUTOLINK_RE = (
     r"(?:\!\[\]|\[([^\]]+)\])\((([^)/]+(\.md|\.png|\.jpg|\.jpeg|\.bmp|\.gif|\.svg|\.webp|/))(#[^)]*)*)(\s(\".*\"))*\)"
 )
 
+AUTOLINK_RE_REFLINKS = (
+    r"(?:\[([^\]]+)\])\: (([^)/]+(\.md|\.png|\.jpg|\.jpeg|\.bmp|\.gif|\.svg|\.webp|/))(#[^)]*)*)(\s(\".*\"))*\n"
+)
+
 class AutoLinkReplacer:
     def __init__(self, base_docs_dir, abs_page_path, filename_to_abs_path):
         self.base_docs_dir = base_docs_dir
@@ -83,6 +87,11 @@ class AutoLinksPlugin(BasePlugin):
         # Look for matches and replace
         markdown = re.sub(
             AUTOLINK_RE,
+            AutoLinkReplacer(base_docs_dir, abs_page_path, self.filename_to_abs_path),
+            markdown,
+        )
+        markdown = re.sub(
+            AUTOLINK_RE_REFLINKS,
             AutoLinkReplacer(base_docs_dir, abs_page_path, self.filename_to_abs_path),
             markdown,
         )


### PR DESCRIPTION
This MR adds support for reference links: https://www.markdownguide.org/basic-syntax/#formatting-the-second-part-of-the-link

and for `index.md` referencing by using `<dirname>/` when file equals `<dirname>\index.md`