### PR TITLE
Don't match single line Code Blocks

### DIFF
--- a/mkdocs_autolinks_plugin/plugin.py
+++ b/mkdocs_autolinks_plugin/plugin.py
@@ -20,7 +20,7 @@ LOG = logging.getLogger("mkdocs.plugins." + __name__)
 #       6. Image title (in quotation marks)
 
 AUTOLINK_RE = (
-    r"(?:\!\[\]|\[([^\]]+)\])\((([^)/]+\.(md|png|jpg|jpeg|bmp|gif|svg|webp))(\#[^)]*)*)(\s(\".*\"))*\)"
+    r"(?!.+`+)(?:\!\[\]|\[([^\]]+)\])\((([^)/]+\.(md|png|jpg|jpeg|bmp|gif|svg|webp))(\#[^)]*)*)(\s(\".*\"))*\)"
 )
 
 class AutoLinkReplacer:

--- a/mkdocs_autolinks_plugin/plugin.py
+++ b/mkdocs_autolinks_plugin/plugin.py
@@ -20,7 +20,7 @@ LOG = logging.getLogger("mkdocs.plugins." + __name__)
 #       6. Image title (in quotation marks)
 
 AUTOLINK_RE = (
-    r"(?:\!\[\]|\[([^\]]+)\])\((([^)/]+\.(md|png|jpg|jpeg|bmp|gif|svg|webp))(#[^)]*)*)(\s(\".*\"))*\)"
+    r"(?:\!\[\]|\[([^\]]+)\])\((([^)/]+\.(md|png|jpg|jpeg|bmp|gif|svg|webp))(\#[^)]*)*)(\s(\".*\"))*\)"
 )
 
 class AutoLinkReplacer:

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ from setuptools import setup, find_packages
 
 setup(
     name='mkdocs-autolinks-plugin',
-    version='0.7.1',
+    version='0.7.2',
     description='An MkDocs plugin',
     long_description='An MkDocs plugin that automagically generates relative links between markdown pages',
     keywords='mkdocs',
     url='https://github.com/midnightprioriem/mkdocs-autolinks-plugin',
-    download_url='https://github.com/midnightprioriem/mkdocs-autolinks-plugin/archive/v_071.tar.gz',
+    download_url='https://github.com/midnightprioriem/mkdocs-autolinks-plugin/archive/v_072.tar.gz',
     author='Zach Hannum',
     author_email='zacharyhannum@gmail.com',
     license='MIT',


### PR DESCRIPTION
This ignores changes to single lined code fences/blocks by prefixing the expression to the existing regex: ``(?!.+`+)``

- [regex101 example](https://regex101.com/r/RK0yq1/1)

````
`[ill-be-ignored](link.md)`

```[ill-also-be-ignored](link.md)```

```markdown
[i-wont-be-ignored-still-sadly](image.png)
```
````
`[ill-be-ignored](link.md)`

```[ill-also-be-ignored](link.md)```

```markdown
[i-wont-be-ignored-still-sadly](image.png)
```

### Note

- an escape `\` was prefixed onto the link fragment `#` in b2cec2a21776b6a0bb58ecf943791bdc176902f8
- while it's still not the ideal solution, this could be used in the interim until someone smarter than me figures out multi-line blocks :P